### PR TITLE
Create B1_escrito LaTeX documentation skeleton

### DIFF
--- a/B1_escrito/README.md
+++ b/B1_escrito/README.md
@@ -1,0 +1,83 @@
+# Carpeta `B1_escrito`
+
+## Propósito general
+Esta carpeta reúne la documentación escrita de los nueve enunciados del bloque B1. Cada ejercicio se desarrolla en un archivo LaTeX dedicado que sigue la misma secuencia metodológica usada en los cuadernos de clase (`trabajo.ipynb`, `trabajo_step_by_step.ipynb`). El objetivo es poder regenerar los resultados numéricos, tablas y figuras a partir de los recursos originales y disponer de un informe autocontenido que explique los procedimientos, decisiones y conclusiones.
+
+## Estructura
+```
+B1_escrito/
+  README.md                ← este índice y guía de reproducción
+  assets/                  ← figuras exportadas de los notebooks
+  enunciado_01/…/enunciado_09/
+      enunciado_##.tex     ← desarrollo completo en LaTeX
+      (enunciado_##.pdf)   ← PDF compilado desde el .tex (generar tras editar)
+  anexos/
+      plantillas.tex       ← macros y tablas de apoyo compartidas
+      (archivos auxiliares)
+```
+
+### Recomendaciones de nomenclatura
+* Las figuras deben guardarse en `assets/` con nombres descriptivos (`e01_zoo_pca.png`, `e07_faces_reconstruccion.png`, etc.).
+* Las tablas extensas o datos intermedios pueden quedar en `anexos/` y enlazarse desde los `.tex` mediante `\input` o `\includegraphics`.
+* Los PDF deben generarse tras editar cada `.tex` con `latexmk -pdf enunciado_##.tex` desde su carpeta correspondiente.
+
+## Reconstrucción de recursos
+1. **Scripts auxiliares (`class_helpers.py`)**
+   * `ensure_practice_paths()` crea la jerarquía esperada de carpetas (`data/`, `img/`, etc.) y descarga los conjuntos si no existen.
+   * `ensure_image_resources()` descarga y descomprime las imágenes `.ppm` utilizadas en los ejercicios de cuantización y estudio de tamaños.
+   * `ensure_faces_dataset()` genera `faces.mat` a partir de las imágenes de rostros; requiere `scipy` para guardar el archivo en formato MATLAB.
+
+   > Ejecuta estos helpers desde la raíz del proyecto o importa las funciones en un cuaderno/notebook.
+
+2. **Dependencias mínimas**
+   * Python 3.9+
+   * `numpy`, `pandas`, `matplotlib`, `seaborn`
+   * `scikit-learn` (K-Means, clustering jerárquico, PCA, métricas)
+   * `scipy` (lectura/escritura de `.mat` y distancias jerárquicas)
+   * `scikit-image` o `Pillow` para cargar/guardar imágenes `.ppm`
+
+3. **Recursos específicos**
+   * `zoo.data`: disponible en `data/zoo/` tras ejecutar `ensure_practice_paths()`.
+   * Imágenes `.ppm`: carpeta `img/ppm/` creada por `ensure_image_resources()`.
+   * `faces.mat`: en `data/faces/`, generado con `ensure_faces_dataset()` (requiere `scikit-learn` para PCA y `scipy.io.savemat`).
+
+## Metodología transversal
+Cada enunciado sigue la misma columna vertebral metodológica:
+1. Carga y descripción de los datos.
+2. Visualización exploratoria y análisis de variables relevantes.
+3. Selección y transformación de características (incluye imputación o tratamiento de ausentes si procede).
+4. Reducción de dimensionalidad y/o escalado.
+5. Tratamiento de desbalanceos cuando aplica.
+6. Modelado o agrupamiento con el algoritmo indicado.
+7. Evaluación cuantitativa y cualitativa.
+8. Interpretación de resultados y conclusiones.
+
+En los `.tex`, cada paso se documenta explícitamente en secciones tituladas **Datos**, **Preprocesamiento**, **Modelado**, **Evaluación** y **Conclusiones**, acompañadas de las figuras/tablas pertinentes.
+
+## Extracto de figuras y tablas
+Para cada enunciado:
+* Exporta las figuras generadas en los notebooks (`trabajo.ipynb`, `trabajo_step_by_step.ipynb`) como PNG o PDF mediante `plt.savefig(...)` y consérvalas en `assets/`.
+* Incluye en los documentos los valores numéricos clave (inercia, silhouette, varianza explicada, F1, tamaños de archivo, etc.) copiándolos directamente de las salidas de los notebooks. Evita depender solo de referencias al código; cada `.tex` debe poder leerse sin ejecutar Python.
+* Anota en el pie de figura o nota al pie cómo se reproduce cada gráfico (nombre del notebook, celda, función utilizada).
+
+## Introducción y conclusión global
+* La introducción general debe resumir los objetivos del bloque B1, contextualizar los datasets (zoo, imágenes, rostros) y mencionar la metodología transversal.
+* La conclusión consolidará las observaciones principales: desempeño comparado de clustering vs. clasificación, efecto de la reducción de dimensionalidad, impacto de la cuantización en las imágenes, etc.
+
+## Checklist de control de calidad
+Incluye en cada `.tex` una checklist en LaTeX similar a:
+```latex
+\begin{itemize}
+  \item[$\square$] Se documenta el preprocesamiento completo.
+  \item[$\square$] Se muestran los cálculos manuales clave.
+  \item[$\square$] Se comparan resultados manuales con los obtenidos por software.
+  \item[$\square$] Se interpretan los resultados en el contexto del problema.
+\end{itemize}
+```
+Esta lista permite verificar que cada ejercicio mantiene coherencia con el resto del dossier.
+
+## Próximos pasos
+1. Completar y revisar `plantillas.tex` con comandos compartidos (formato de tablas, macros para checklist, estilos de figuras).
+2. Tras rellenar cada documento, compilar el PDF y subirlo a la carpeta correspondiente.
+3. Realizar una revisión ortográfica y técnica final antes de entregar.
+

--- a/B1_escrito/anexos/plantillas.tex
+++ b/B1_escrito/anexos/plantillas.tex
@@ -1,0 +1,50 @@
+% Plantillas y macros compartidas para los informes B1
+\ProvidesFile{plantillas.tex}[2024/04/20 Plantillas compartidas B1]
+
+% Paquetes base recomendados para todos los enunciados
+\usepackage[spanish]{babel}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{amsmath, amssymb}
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage{siunitx}
+\usepackage{float}
+\usepackage{enumitem}
+\usepackage{geometry}
+\geometry{a4paper, margin=2.5cm}
+
+% Configuración de siunitx para porcentajes y decimales
+\sisetup{round-mode=places, round-precision=3, detect-all}
+
+% Checklist reutilizable
+\newlist{checklist}{itemize}{1}
+\setlist[checklist]{label=$\square$, left=1.5em, itemsep=0.2em}
+
+\newcommand{\ChecklistBase}{%
+  \begin{checklist}
+    \item Se documenta el preprocesamiento completo.
+    \item Se muestran los cálculos manuales clave.
+    \item Se comparan resultados manuales con los obtenidos por software.
+    \item Se interpretan los resultados en el contexto del problema.
+  \end{checklist}%
+}
+
+% Entorno para resaltar procedimientos paso a paso
+\newenvironment{pasoapaso}{%
+  \begin{enumerate}[label=Paso~\arabic*:, leftmargin=*, itemsep=0.4em]
+}{%
+  \end{enumerate}
+}
+
+% Formato estándar de tablas comparativas
+\newcommand{\TablaComparativa}[3]{%
+  \begin{table}[H]
+    \centering
+    \caption{#1}
+    \label{#2}
+    #3
+  \end{table}
+}
+
+% Nota: cada documento debe `\input{../anexos/plantillas.tex}` tras `\documentclass`.

--- a/B1_escrito/enunciado_01/enunciado_01.tex
+++ b/B1_escrito/enunciado_01/enunciado_01.tex
@@ -1,0 +1,44 @@
+\documentclass[12pt]{article}
+\input{../anexos/plantillas.tex}
+\title{Enunciado 01 -- Zoo y K-Means}
+\author{Dossier B1}
+\date{\today}
+
+\begin{document}
+\maketitle
+\section{Objetivo}
+Documentar el proceso completo de agrupamiento K-Means aplicado al conjunto \emph{zoo}, comparando configuraciones con y sin la variable \texttt{type} y justificando la elección del número de clústeres.
+
+\section{Datos y preprocesamiento}
+\begin{pasoapaso}
+  \item Describir los atributos del dataset, destacando variables binarias y numéricas (por ejemplo, \texttt{legs}).
+  \item Explicar la imputación/limpieza necesaria y la justificación del escalado (normalización o estandarización) de \texttt{legs} y del resto de variables.
+  \item Indicar cómo se separó el conjunto para las versiones con y sin \texttt{type}.
+\end{pasoapaso}
+
+\section{Modelado}
+\begin{pasoapaso}
+  \item Mostrar las iteraciones iniciales de K-Means calculando manualmente distancias Euclídeas para un subconjunto representativo (incluir tabla de distancias y asignaciones).
+  \item Registrar las ejecuciones del algoritmo para varios valores de $k$ (inercia, silhouette, ARI con respecto a \texttt{type}).
+  \item Incluir proyecciones 2D mediante PCA con y sin \texttt{type}, referenciando figuras en `assets/`.
+\end{pasoapaso}
+
+\section{Evaluación e interpretación}
+\TablaComparativa{Métricas por número de clústeres}{tab:metrics}{%
+  \begin{tabular}{lccc}
+    \toprule
+    $k$ & Inercia & Coeficiente silhouette & ARI \\
+    \midrule
+    % Completar con valores reales
+    \bottomrule
+  \end{tabular}
+}
+Discutir la elección final de $k$ y comparar los resultados obtenidos con y sin la variable \texttt{type}, enfatizando las diferencias en la separación de especies.
+
+\section{Conclusiones}
+Resumir los hallazgos principales, destacando la utilidad del escalado, el valor óptimo de $k$ y la interpretación biológica de los clústeres.
+
+\section*{Checklist}
+\ChecklistBase
+
+\end{document}

--- a/B1_escrito/enunciado_02/enunciado_02.tex
+++ b/B1_escrito/enunciado_02/enunciado_02.tex
@@ -1,0 +1,40 @@
+\documentclass[12pt]{article}
+\input{../anexos/plantillas.tex}
+\title{Enunciado 02 -- Zoo y clustering jerárquico}
+\author{Dossier B1}
+\date{\today}
+
+\begin{document}
+\maketitle
+\section{Objetivo}
+Analizar el dataset \emph{zoo} mediante técnicas de clustering jerárquico, comparando diferentes criterios de enlace y distancias para interpretar la estructura taxonómica implícita.
+
+\section{Datos y preprocesamiento}
+Reutilizar la preparación del Enunciado~01 (escalado, selección de variables), explicitando cualquier diferencia necesaria para la distancia jerárquica.
+
+\section{Metodología}
+\begin{pasoapaso}
+  \item Justificar la métrica de distancia elegida (Euclídea, Manhattan, etc.) y mostrar un ejemplo manual del cálculo entre dos animales, incluyendo una tabla detallada.
+  \item Generar dendrogramas para los enlaces \emph{single}, \emph{complete} y \emph{average}; enlazar cada figura exportada en `assets/` indicando cómo reproducirla.
+  \item Comparar cortes horizontales específicos y mostrar cómo cambian las asignaciones de clústeres.
+\end{pasoapaso}
+
+\section{Resultados}
+\TablaComparativa{Comparativa de enlaces}{tab:enlaces}{%
+  \begin{tabular}{lccc}
+    \toprule
+    Enlace & Altura óptima & Número de clústeres & Observaciones \\
+    \midrule
+    % Rellenar con resultados reales
+    \bottomrule
+  \end{tabular}
+}
+Incluir discusión textual sobre las diferencias entre enlaces y la coherencia con la taxonomía real.
+
+\section{Conclusiones}
+Sintetizar qué configuración ofrece la mejor separación y cómo se relaciona con las categorías de \texttt{type}.
+
+\section*{Checklist}
+\ChecklistBase
+
+\end{document}

--- a/B1_escrito/enunciado_03/enunciado_03.tex
+++ b/B1_escrito/enunciado_03/enunciado_03.tex
@@ -1,0 +1,37 @@
+\documentclass[12pt]{article}
+\input{../anexos/plantillas.tex}
+\title{Enunciado 03 -- DBSCAN sobre 12 puntos}
+\author{Dossier B1}
+\date{\today}
+
+\begin{document}
+\maketitle
+\section{Objetivo}
+Resolver manualmente el proceso de agrupamiento con DBSCAN para un conjunto de doce puntos, identificando núcleo, frontera y ruido en función de $\varepsilon$ y `minPts`.
+
+\section{Datos de partida}
+Describir la distribución de los 12 puntos (coordenadas o matriz de distancias), incluyendo una figura ilustrativa desde los notebooks.
+
+\section{Cálculo de distancias}
+Presentar la tabla completa de distancias entre puntos.
+\TablaComparativa{Distancias Euclídeas}{tab:distancias}{%
+  % Incluir tabular con distancias calculadas manualmente
+}
+
+\section{Aplicación de DBSCAN}
+\begin{pasoapaso}
+  \item Definir explícitamente los parámetros $\varepsilon$ y `minPts`.
+  \item Marcar vecinos directos y puntos densamente alcanzables, justificando cada clasificación.
+  \item Construir los clústeres paso a paso hasta etiquetar todos los puntos o catalogarlos como ruido.
+\end{pasoapaso}
+
+\section{Resultados y discusión}
+Incluir tabla resumen con los clústeres finales y la categoría de cada punto. Explicar por qué ciertos puntos se consideran ruido y cómo cambiaría la asignación variando $\varepsilon$.
+
+\section{Conclusiones}
+Destacar la utilidad de DBSCAN frente a métodos de partición cuando hay ruido o densidades diferentes.
+
+\section*{Checklist}
+\ChecklistBase
+
+\end{document}

--- a/B1_escrito/enunciado_04/enunciado_04.tex
+++ b/B1_escrito/enunciado_04/enunciado_04.tex
@@ -1,0 +1,40 @@
+\documentclass[12pt]{article}
+\input{../anexos/plantillas.tex}
+\title{Enunciado 04 -- Funciones helper de imágenes}
+\author{Dossier B1}
+\date{\today}
+
+\begin{document}
+\maketitle
+\section{Objetivo}
+Documentar las funciones auxiliares empleadas para cargar, guardar, cuantizar y visualizar imágenes dentro del proyecto, enfatizando el flujo de datos y la gestión de rutas.
+
+\section{Funciones clave}
+\begin{description}[leftmargin=!,labelwidth=5cm]
+  \item[\texttt{load\_ppm(path)}] Describir parámetros de entrada, estructura de retorno (matriz RGB) y validaciones realizadas.
+  \item[\texttt{save\_ppm(path, image)}] Explicar el formato de salida, conversión de tipos y manejo de carpetas destino.
+  \item[\texttt{quantize\_image(image, palette)}] Detallar el algoritmo de cuantización (p.ej. asignación al centroide más cercano) y complejidad.
+  \item[\texttt{show\_comparison(original, processed)}] Indicar cómo se generan figuras lado a lado y cómo se integran en los notebooks.
+\end{description}
+
+\section{Diagramas de flujo}
+Insertar diagramas exportados desde los notebooks o creados con herramientas externas para ilustrar:
+\begin{itemize}
+  \item Ciclo de carga\,$\rightarrow$\,procesamiento\,$\rightarrow$\,guardado.
+  \item Integración con los helpers de \texttt{class\_helpers.py}.
+\end{itemize}
+Las imágenes deben guardarse en `assets/` y referenciarse mediante `\includegraphics`.
+
+\section{Tratamiento de matrices de píxeles}
+Explicar cómo se manipulan las matrices (dimensiones, canales, normalización) y cómo se manejan posibles valores fuera de rango. Incluir ejemplos numéricos.
+
+\section{Gestión de rutas y reproducibilidad}
+Detallar cómo se construyen rutas relativas a partir de la raíz del proyecto y cómo los helpers aseguran la existencia de directorios (usar \texttt{ensure\_practice\_paths}).
+
+\section{Conclusiones}
+Resumir buenas prácticas y validaciones implementadas para evitar corrupción de archivos o errores de lectura.
+
+\section*{Checklist}
+\ChecklistBase
+
+\end{document}

--- a/B1_escrito/enunciado_05/enunciado_05.tex
+++ b/B1_escrito/enunciado_05/enunciado_05.tex
@@ -1,0 +1,37 @@
+\documentclass[12pt]{article}
+\input{../anexos/plantillas.tex}
+\title{Enunciado 05 -- Reducción de color en imágenes}
+\author{Dossier B1}
+\date{\today}
+
+\begin{document}
+\maketitle
+\section{Objetivo}
+Describir el proceso de cuantización de color (p.ej. K-Means sobre el espacio RGB) aplicado a las imágenes del conjunto `img/ppm/`, destacando la selección de centroides y el efecto visual/numerico de la reducción.
+
+\section{Metodología}
+\begin{pasoapaso}
+  \item Presentar el algoritmo elegido (K-Means u otra técnica), incluyendo la inicialización de centroides y criterios de convergencia.
+  \item Cuantizar paso a paso una imagen pequeña de ejemplo (matriz $4\times4$ o similar) mostrando las asignaciones manuales.
+  \item Aplicar el procedimiento a las imágenes reales y guardar las versiones cuantizadas en `assets/`.
+\end{pasoapaso}
+
+\section{Resultados}
+\TablaComparativa{Conteo de colores tras cuantización}{tab:colores}{%
+  \begin{tabular}{lccc}
+    \toprule
+    Imagen & Colores originales & Colores tras cuantización & Error MSE \\
+    \midrule
+    % Completar con datos reales
+    \bottomrule
+  \end{tabular}
+}
+Incluir figuras comparativas (antes/después) y discutir la calidad percibida.
+
+\section{Conclusiones}
+Analizar el compromiso entre reducción de colores y fidelidad visual, así como recomendaciones para seleccionar $k$.
+
+\section*{Checklist}
+\ChecklistBase
+
+\end{document}

--- a/B1_escrito/enunciado_06/enunciado_06.tex
+++ b/B1_escrito/enunciado_06/enunciado_06.tex
@@ -1,0 +1,40 @@
+\documentclass[12pt]{article}
+\input{../anexos/plantillas.tex}
+\title{Enunciado 06 -- Estudio del tamaño de archivos de imagen}
+\author{Dossier B1}
+\date{\today}
+
+\begin{document}
+\maketitle
+\section{Objetivo}
+Analizar cómo varían los tamaños de archivo al guardar las imágenes en distintos formatos (PPM, PNG, JPEG, etc.) y evaluar el compromiso entre compresión y calidad.
+
+\section{Procedimiento}
+\begin{pasoapaso}
+  \item Listar los formatos evaluados y las herramientas empleadas para convertir/medir el tamaño (scripts de Python o utilidades del sistema).
+  \item Registrar tamaños antes y después de la cuantización de colores (si aplica), indicando rutas y comandos utilizados.
+  \item Documentar cualquier ajuste de calidad (nivel de compresión JPEG, profundidad de bits, etc.).
+\end{pasoapaso}
+
+\section{Resultados}
+\TablaComparativa{Tamaños por formato}{tab:tamanos}{%
+  \begin{tabular}{lccc}
+    \toprule
+    Imagen & Formato & Tamaño (kB) & Ahorro porcentual \\
+    \midrule
+    % Completar con datos reales
+    \bottomrule
+  \end{tabular}
+}
+Acompañar con figuras de comparación visual para ilustrar el impacto en calidad.
+
+\section{Discusión}
+Analizar las tendencias observadas, destacar el mejor formato en términos de relación compresión/calidad e incluir cálculos percentuales detallados.
+
+\section{Conclusiones}
+Recomendar formatos y configuraciones para distintos escenarios (almacenamiento vs. visualización).
+
+\section*{Checklist}
+\ChecklistBase
+
+\end{document}

--- a/B1_escrito/enunciado_07/enunciado_07.tex
+++ b/B1_escrito/enunciado_07/enunciado_07.tex
@@ -1,0 +1,34 @@
+\documentclass[12pt]{article}
+\input{../anexos/plantillas.tex}
+\title{Enunciado 07 -- PCA sobre rostros}
+\author{Dossier B1}
+\date{\today}
+
+\begin{document}
+\maketitle
+\section{Objetivo}
+Explicar el proceso de reducción de dimensionalidad mediante PCA sobre el conjunto `faces.mat`, documentando la construcción de la matriz de covarianzas, el cálculo de autovalores/autovectores y la reconstrucción de rostros.
+
+\section{Preparación de datos}
+Describir cómo se cargan las imágenes desde `faces.mat`, su vectorización y la normalización previa.
+
+\section{Cálculo de PCA}
+\begin{pasoapaso}
+  \item Derivar la fórmula de la matriz de covarianzas y especificar su dimensionalidad.
+  \item Resumir el cálculo de autovalores y autovectores (mostrar primeros valores y su interpretación).
+  \item Mostrar cómo se selecciona el número de componentes principales y cómo se proyectan los rostros.
+\end{pasoapaso}
+
+\section{Reconstrucciones}
+Incluir figuras (antes/después) de al menos dos rostros, señalando el número de componentes usados. Explicar cómo se realiza la reconstrucción y cuantificar el error (RMSE o PSNR).
+
+\section{Discusión}
+Analizar qué características capturan los primeros componentes y cómo influyen en la variabilidad entre rostros.
+
+\section{Conclusiones}
+Resumir los beneficios de PCA en compresión y reconocimiento facial.
+
+\section*{Checklist}
+\ChecklistBase
+
+\end{document}

--- a/B1_escrito/enunciado_08/enunciado_08.tex
+++ b/B1_escrito/enunciado_08/enunciado_08.tex
@@ -1,0 +1,37 @@
+\documentclass[12pt]{article}
+\input{../anexos/plantillas.tex}
+\title{Enunciado 08 -- Varianza explicada por PCA}
+\author{Dossier B1}
+\date{\today}
+
+\begin{document}
+\maketitle
+\section{Objetivo}
+Cuantificar y analizar la varianza explicada acumulada por los componentes principales del conjunto de rostros, justificando cuántos componentes son necesarios para distintos umbrales.
+
+\section{Metodología}
+\begin{pasoapaso}
+  \item Derivar la fórmula de varianza explicada individual y acumulada a partir de los autovalores.
+  \item Construir una tabla con la varianza acumulada y marcar los umbrales de 80\%, 90\%, 95\% y 99\%.
+  \item Representar gráficamente (en `assets/`) la curva de varianza acumulada y explicar su interpretación.
+\end{pasoapaso}
+
+\section{Resultados}
+\TablaComparativa{Varianza explicada acumulada}{tab:varianza}{%
+  \begin{tabular}{lcc}
+    \toprule
+    Componentes & Varianza individual (\%) & Varianza acumulada (\%) \\
+    \midrule
+    % Completar con datos reales
+    \bottomrule
+  \end{tabular}
+}
+Discutir el número de componentes recomendados para cada umbral y las implicaciones en tiempo de cómputo y calidad de reconstrucción.
+
+\section{Conclusiones}
+Resumir los criterios de selección de componentes y cómo se relacionan con el Enunciado~09.
+
+\section*{Checklist}
+\ChecklistBase
+
+\end{document}

--- a/B1_escrito/enunciado_09/enunciado_09.tex
+++ b/B1_escrito/enunciado_09/enunciado_09.tex
@@ -1,0 +1,40 @@
+\documentclass[12pt]{article}
+\input{../anexos/plantillas.tex}
+\title{Enunciado 09 -- Clasificación con y sin PCA}
+\author{Dossier B1}
+\date{\today}
+
+\begin{document}
+\maketitle
+\section{Objetivo}
+Comparar el rendimiento de distintos clasificadores sobre el conjunto de rostros (u otro dataset correspondiente) con y sin reducción de dimensionalidad mediante PCA.
+
+\section{Diseño experimental}
+\begin{pasoapaso}
+  \item Describir el conjunto de datos, partición de entrenamiento/prueba y tratamiento de desbalanceos.
+  \item Especificar los modelos evaluados (p.ej. SVM, k-NN, Regresión Logística) y sus hiperparámetros.
+  \item Definir las métricas de evaluación (accuracy, F1, matrices de confusión) y la metodología de validación (hold-out, cross-validation).
+\end{pasoapaso}
+
+\section{Resultados}
+\TablaComparativa{Rendimiento con y sin PCA}{tab:clasificacion}{%
+  \begin{tabular}{lcccc}
+    \toprule
+    Modelo & Configuración & Accuracy & F1 macro & Observaciones \\
+    \midrule
+    % Completar con datos reales
+    \bottomrule
+  \end{tabular}
+}
+Incluir matrices de confusión y discutir cambios en precisión/recobrado.
+
+\section{Discusión}
+Analizar por qué PCA puede mejorar o empeorar el rendimiento: efectos en ruido, sobreajuste y tiempo de cómputo. Incluir reflexión sobre balanceo de clases y estrategias para mitigarlo.
+
+\section{Conclusiones}
+Sintetizar las lecciones aprendidas y recomendaciones para aplicar PCA antes de la clasificación.
+
+\section*{Checklist}
+\ChecklistBase
+
+\end{document}

--- a/B1_escrito/introduccion_conclusion.tex
+++ b/B1_escrito/introduccion_conclusion.tex
@@ -1,0 +1,25 @@
+\documentclass[12pt]{article}
+\input{anexos/plantillas.tex}
+\title{Dossier B1 -- Introducción y Conclusiones Generales}
+\author{Dossier B1}
+\date{\today}
+
+\begin{document}
+\maketitle
+\section{Introducción}
+Presentar los objetivos globales del bloque B1, contextualizando los conjuntos de datos utilizados (\emph{zoo}, imágenes \texttt{ppm}, \texttt{faces.mat}) y describiendo la metodología transversal aplicada en los nueve enunciados. Incluir un mapa conceptual o figura resumen ubicada en `assets/` que ilustre el flujo: adquisición de datos $\rightarrow$ preprocesamiento $\rightarrow$ modelado $\rightarrow$ evaluación.
+
+\section{Resumen de hallazgos}
+\begin{itemize}
+  \item Sintetizar resultados clave de clustering (Enunciados 01--03), resaltando métricas como inercia, silhouette y ARI.
+  \item Resumir aportes de los enunciados orientados a imágenes (04--06) respecto a tratamiento de píxeles y eficiencia de almacenamiento.
+  \item Destacar las implicaciones de PCA sobre rostros (07--08) y su impacto en la clasificación (09).
+\end{itemize}
+
+\section{Conclusiones globales}
+Conectar los hallazgos, discutiendo cómo la reducción de dimensionalidad y el preprocesamiento afectan el desempeño tanto en clustering como en clasificación. Incluir recomendaciones generales para futuros trabajos y posibles extensiones (por ejemplo, probar t-SNE o UMAP, explorar métodos de balanceo avanzados).
+
+\section*{Checklist}
+\ChecklistBase
+
+\end{document}


### PR DESCRIPTION
## Summary
- add the B1_escrito documentation folder with README guidance and resource reconstruction notes
- provide shared LaTeX templates and individual enunciado placeholders aligned with the requested methodology
- include an introduction/conclusion document and asset placeholders for future figures

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e4f58afda8832188b0315097e71858